### PR TITLE
Fix switch expression syntax and LocalSource usage

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -14,7 +14,7 @@ class HomeScreen extends ConsumerWidget {
     final matchesState = ref.watch(
       query<BjjMatch>(
         // Use local storage for deduplicated results
-        source: LocalSource(stream: true),
+        source: LocalSource(),
       ),
     );
 
@@ -44,7 +44,7 @@ class HomeScreen extends ConsumerWidget {
                 ],
               ),
             ),
-          StorageData(:final models) {
+          StorageData(:final models) => () {
             // Deduplicate matches by matchId and take the latest version
             final matches = _deduplicateMatches(
               models.cast<BjjMatch>(),
@@ -52,40 +52,40 @@ class HomeScreen extends ConsumerWidget {
 
             return matches.isEmpty
                 ? Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(
-                        Icons.sports_mma,
-                        size: 64,
-                        color: Colors.grey[400],
-                      ),
-                      const SizedBox(height: 16),
-                      Text(
-                        'No matches yet',
-                        style: Theme.of(context).textTheme.headlineSmall,
-                      ),
-                      const SizedBox(height: 8),
-                      Text(
-                        'Create your first BJJ match to get started',
-                        style: Theme.of(context).textTheme.bodyMedium,
-                        textAlign: TextAlign.center,
-                      ),
-                      const SizedBox(height: 24),
-                      ElevatedButton.icon(
-                        onPressed: () => context.push('/create'),
-                        icon: const Icon(Icons.add),
-                        label: const Text('Create Match'),
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor:
-                              Theme.of(context).colorScheme.primary,
-                          foregroundColor:
-                              Theme.of(context).colorScheme.onPrimary,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(
+                          Icons.sports_mma,
+                          size: 64,
+                          color: Colors.grey[400],
                         ),
-                      ),
-                    ],
-                  ),
-                )
+                        const SizedBox(height: 16),
+                        Text(
+                          'No matches yet',
+                          style: Theme.of(context).textTheme.headlineSmall,
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          'Create your first BJJ match to get started',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 24),
+                        ElevatedButton.icon(
+                          onPressed: () => context.push('/create'),
+                          icon: const Icon(Icons.add),
+                          label: const Text('Create Match'),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor:
+                                Theme.of(context).colorScheme.primary,
+                            foregroundColor:
+                                Theme.of(context).colorScheme.onPrimary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  )
                 : Column(
                     children: [
                       // Status filters
@@ -117,7 +117,7 @@ class HomeScreen extends ConsumerWidget {
                       ),
                     ],
                   );
-          },
+          }(),
         },
       ),
       floatingActionButton: FloatingActionButton(
@@ -136,7 +136,7 @@ List<BjjMatch> _deduplicateMatches(List<BjjMatch> matches) {
   for (final match in matches) {
     final existing = latest[match.matchId];
     if (existing == null ||
-        match.event.createdAt > existing.event.createdAt) {
+        match.event.createdAt.isAfter(existing.event.createdAt)) {
       latest[match.matchId] = match;
     }
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -132,17 +132,20 @@ class HomeScreen extends ConsumerWidget {
 
 // Deduplicate matches by their address (matchId) and keep latest version
 List<BjjMatch> _deduplicateMatches(List<BjjMatch> matches) {
+  final defaultDate = DateTime.fromMillisecondsSinceEpoch(0);
   final Map<String, BjjMatch> latest = {};
   for (final match in matches) {
     final existing = latest[match.matchId];
     if (existing == null ||
-        match.event.createdAt.isAfter(existing.event.createdAt)) {
+        (match.event.createdAt ?? defaultDate)
+            .isAfter(existing.event.createdAt ?? defaultDate)) {
       latest[match.matchId] = match;
     }
   }
   final result = latest.values.toList();
   result.sort(
-    (a, b) => b.event.createdAt.compareTo(a.event.createdAt),
+    (a, b) => (b.event.createdAt ?? defaultDate)
+        .compareTo(a.event.createdAt ?? defaultDate),
   );
   return result;
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -136,9 +136,11 @@ List<BjjMatch> _deduplicateMatches(List<BjjMatch> matches) {
   final Map<String, BjjMatch> latest = {};
   for (final match in matches) {
     final existing = latest[match.matchId];
+    final matchDate = match.event.createdAt;
+    final existingDate = existing?.event.createdAt;
     if (existing == null ||
-        (match.event.createdAt ?? defaultDate)
-            .isAfter(existing.event.createdAt ?? defaultDate)) {
+        (matchDate != null &&
+            (existingDate == null || matchDate.isAfter(existingDate)))) {
       latest[match.matchId] = match;
     }
   }

--- a/lib/screens/match_screen.dart
+++ b/lib/screens/match_screen.dart
@@ -76,7 +76,11 @@ class MatchScreen extends HookConsumerWidget {
 
 // Select the newest version of a match from a list
 BjjMatch _latestMatch(List<BjjMatch> matches) {
-  matches.sort((a, b) => b.event.createdAt.compareTo(a.event.createdAt));
+  final defaultDate = DateTime.fromMillisecondsSinceEpoch(0);
+  matches.sort(
+    (a, b) => (b.event.createdAt ?? defaultDate)
+        .compareTo(a.event.createdAt ?? defaultDate),
+  );
   return matches.first;
 }
 

--- a/lib/screens/match_screen.dart
+++ b/lib/screens/match_screen.dart
@@ -19,7 +19,7 @@ class MatchScreen extends HookConsumerWidget {
       query<BjjMatch>(
         tags: {'#d': {matchId}},
         // Use local storage to leverage built-in deduplication
-        source: LocalSource(stream: true),
+        source: LocalSource(),
       ),
     );
 
@@ -46,7 +46,7 @@ class MatchScreen extends HookConsumerWidget {
             ),
           ),
         ),
-      StorageData(:final models) {
+      StorageData(:final models) => () {
         if (models.isEmpty) {
           return Scaffold(
             appBar: AppBar(title: const Text('Match Not Found')),
@@ -69,7 +69,7 @@ class MatchScreen extends HookConsumerWidget {
         }
         final match = _latestMatch(models.cast<BjjMatch>());
         return MatchControlWidget(match: match);
-      },
+      }(),
     };
   }
 }


### PR DESCRIPTION
## Summary
- fix HomeScreen and MatchScreen `LocalSource` usage and switch expression syntax
- ensure match deduplication uses `isAfter` for DateTime comparison

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a31ec1b40832db9b035158e98fe36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Not-found screens now show the specific match ID when a match is missing.

- Bug Fixes
  - More robust date handling so newest matches reliably appear first, even with missing timestamps.
  - Improved match selection and ordering to prevent incorrect detail views.
  - More stable local data loading and consistent empty-state rendering.

- Refactor
  - Streamlined data-loading and UI builder flow in Home and Match screens for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->